### PR TITLE
Add code to count moves based on a different move definition

### DIFF
--- a/countNormlized.ts
+++ b/countNormlized.ts
@@ -1,0 +1,38 @@
+import { readFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+
+export async function countNormalized() {
+    const resultsData = JSON.parse(await readFile('results.json', { encoding: 'utf8' }));
+    const counter = new CounterMap;
+    for (const [move, moveCount] of Object.entries(resultsData.moves as Record<string, number>)) {
+        const normalizedMove = normalizeMove(move);
+        counter.add(normalizedMove, moveCount);
+    }
+    const sortedCounts = Object.fromEntries(Array.from(counter).sort(([, count1], [, count2]) => count2 - count1));
+    const sortedCountsJson = JSON.stringify(sortedCounts, null, 4);
+    console.log(sortedCountsJson);
+}
+
+const moveRegex = /^([KQRBN]?)([a-h]?[0-9]?)x?([a-h][0-9])((?:=[QRBN])?)[+#]?$/;
+
+function normalizeMove(move: string): string {
+    if (move[0] == 'O') return move.replace(/[+#]/g, ''); // castling moves
+    const parts = move.match(moveRegex);
+    if (parts == null) throw new Error(`unexpected move format '${move}'`);
+    const [ _, piece, origin, destination, promotion ] = parts;
+    const normalizedMove = `${piece}${destination}${promotion}`;
+    return normalizedMove;
+}
+
+class CounterMap extends Map<string, number> {
+    get(key: string): number {
+        return super.get(key) ?? 0;
+    }
+    add(key: string, value: number) {
+        return this.set(key, this.get(key) + value);
+    }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+    await countNormalized();
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "type": "module",
+  "devDependencies": {
+    "@types/node": "^20.14.2"
+  }
+}


### PR DESCRIPTION
I am curious to know what would be the top 10 most rare moves using a different move definition. I'd define a move as a tuple: piece (including color), source square, destination square and final piece (only relevant for promotions). Would not care about notation aspects such as check, checkmate or capture.

Ended up doing a simpler version of this idea ignoring both piece color and source square. This way I could just take the existing results.json as input. The most rare moves using this definition are the 16 bishop underpromotions, the top 1 being e1=B played only 111,416 times.

Let me know if you'd like me to change something.